### PR TITLE
rwt_moveit: Fixing import errors in interactive_moveit.py

### DIFF
--- a/rwt_moveit/nodes/interactive_moveit.py
+++ b/rwt_moveit/nodes/interactive_moveit.py
@@ -10,12 +10,12 @@ from std_msgs.msg import String
 from std_msgs.msg import Float32
 from std_msgs.msg import MultiArrayDimension
 from sensor_msgs.msg import JointState
-from interactive_markers.interactive_marker_server import (
+from visualization_msgs.msg import (
     Marker,
     InteractiveMarker,
-    InteractiveMarkerServer,
     InteractiveMarkerControl,
     InteractiveMarkerFeedback)
+from interactive_markers.interactive_marker_server import InteractiveMarkerServer
 server = None
 
 


### PR DESCRIPTION
@130s this fixes the broken import exceptions for me referenced here:

https://github.com/tork-a/visualization_rwt/issues/36
