### PR TITLE
fix for robot defined with link chain

### DIFF
--- a/rwt_moveit/nodes/interactive_moveit.py
+++ b/rwt_moveit/nodes/interactive_moveit.py
@@ -17,6 +17,10 @@ from visualization_msgs.msg import (
     InteractiveMarkerFeedback)
 from interactive_markers.interactive_marker_server import InteractiveMarkerServer
 server = None
+group_name = 'manipulator'
+joint_states = None
+joint_names = []
+initial_joint_position = []
 
 
 def makeInteractiveMarker(name, description):

--- a/rwt_moveit/nodes/interactive_moveit.py
+++ b/rwt_moveit/nodes/interactive_moveit.py
@@ -53,7 +53,7 @@ def setColor(red, green, blue, alpha, marker):
 
 
 def callback(req):
-    print req
+    rospy.logwarn(req)
     return GetPositionIKResponse
 
 def initial_callback(msg):
@@ -111,9 +111,9 @@ def feedback(feedback):
 
         request.ik_request.pose_stamped = pose_stamped
         response = service(request)
-        print response
+        rospy.logwarn(response)
         if len(response.solution.joint_state.position) != 0:
-            print "success"
+            rospy.loginfo("GetPositionIK succeeded")
             msg = Float64MultiArray()
             for i,joint_name in enumerate(response.solution.joint_state.name):
                 for j, name in enumerate(joint_names):

--- a/rwt_moveit/nodes/link_group_publisher
+++ b/rwt_moveit/nodes/link_group_publisher
@@ -2,7 +2,9 @@
 
 import roslib
 import rospy
+import sys
 import xml.dom.minidom
+from urdf_parser_py.urdf import URDF
 
 def get_param(name, value=None):
     private = "~%s" % name
@@ -19,6 +21,7 @@ def set_param(name, value):
 
 
 def set_param():
+    robot = URDF.from_parameter_server()
     description = get_param('robot_description_semantic')
     group_description = xml.dom.minidom.parseString(description).getElementsByTagName('group')
     effector_description = xml.dom.minidom.parseString(description).getElementsByTagName('end_effector')
@@ -28,13 +31,18 @@ def set_param():
         for child in group_name.childNodes:
             if child.nodeType is child.TEXT_NODE:
                 continue
-            links.append(child.getAttribute('name'))
-        rospy.set_param('~' + name, links)
+            if child.getAttribute('name'):
+                links.append(child.getAttribute('name'))
+            if child.getAttribute('base_link') and child.getAttribute('tip_link') :
+                links.extend(robot.get_chain(child.getAttribute('base_link'),child.getAttribute('tip_link'), joints=True, links=False, fixed=False))
+        print('SET PARAM : ' + '/link_group/' + name, links)
+        rospy.set_param('/link_group/' + name, links)
     for effector_name in effector_description:
         if effector_name.nodeType is effector_name.TEXT_NODE:
             continue
         link_name = effector_name.getAttribute('parent_link')
-        group_name = effector_name.getAttribute('parent_group')
+        group_name = effector_name.getAttribute('group')
+        print('SET PARAM : ' + '/end_effector_link/' + group_name, link_name)
         rospy.set_param('/end_effector_link/' + group_name, link_name)
 
 
@@ -44,3 +52,4 @@ if __name__ == '__main__':
         rospy.init_node('link_group_publisher')
         set_param()
     except rospy.ROSInterruptException: pass
+    sys.exit(0)

--- a/rwt_moveit/nodes/moveit_publisher.py
+++ b/rwt_moveit/nodes/moveit_publisher.py
@@ -81,12 +81,14 @@ def joint_position_callback(joints):
         else:
             plan_only = False
 
+        rospy.loginfo("send move_group_goal {}".format(move_group_goal))
         client.send_goal(move_group_goal)
-        client.wait_for_result(rospy.Duration.from_sec(5.0))
+        result = client.wait_for_result(rospy.Duration.from_sec(5.0))
+        rospy.loginfo("move_group_goal result {}".format(result))
 
 
     except rospy.ROSInterruptException, e:
-        print "failed: %s"%e
+        rospy.logerr("failed: %s".format(e))
 
 
 def moveit_callback(msg):

--- a/rwt_moveit/nodes/virtual_joint_state_publisher
+++ b/rwt_moveit/nodes/virtual_joint_state_publisher
@@ -2,7 +2,6 @@
 
 import roslib; roslib.load_manifest('joint_state_publisher')
 import rospy
-import wx
 import xml.dom.minidom
 from sensor_msgs.msg import JointState
 from math import pi


### PR DESCRIPTION
requires https://github.com/tork-a/rwt_ros/pull/20
ur5 used in https://github.com/tork-a/visualization_rwt/issues/65 uses `chain` for group settings, so it needs to read urdf to get link chain.

```
    <group name="manipulator">
        <chain base_link="base_link" tip_link="ee_link" />
    </group>
    <group name="endeffector">
        <link name="ee_link" />
    </group>
```
