### PR TITLE
update nodejs version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,17 @@ env:
     - ROS_DISTRO=jade
 sudo: required
 dist: trusty
-# Force travis to use its minimal image with default Python settings
 language: node_js
+matrix:
+  fast_finish: true
+  allow_failures:
+    - node_js: "0.10"  # builtin nodejs on ubuntu 14.04 is too old
 node_js:
-  - "0.10"
-  - "0.12"
-  - "4"
-#notifications:
-#  Whoever receives success and/or failure via email
+  - "0.10"   # ubuntu 14.04 builtin
+  - "4"      # ubuntu 16.04 builtin
+  - "stable" # latest stable release
 before_script:
+  # Force travis to use its minimal image with default Python settings
   - sudo rm -fr /opt/python/
   - export CI_SOURCE_PATH=$(pwd)
   - export REPOSITORY_NAME=${PWD##*/}


### PR DESCRIPTION
Currently, testing fails since builtin nodejs on ubuntu 14.04 is too old.
This pull request updates `.travis.yml`:
- add node js `0.10` to `allow_failures`
- add `stable` nodejs to be tested
- cleanup comments in `.travis.yml`

```
/home/travis/.nvm/v0.10.48/lib/node_modules/npm/lib/utils/unsupported.js:28
        console.error(`a bug known to break npm. Please update to at least ${r
                      ^
SyntaxError: Unexpected token ILLEGAL
    at Module._compile (module.js:439:25)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at /home/travis/.nvm/v0.10.48/lib/node_modules/npm/bin/npm-cli.js:19:21
    at Object.<anonymous> (/home/travis/.nvm/v0.10.48/lib/node_modules/npm/bin/npm-cli.js:92:3)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
```
  