### PR TITLE
fix travis

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+set -e
+
+function travis_time_start {
+    set +x
+    TRAVIS_START_TIME=$(date +%s%N)
+    TRAVIS_TIME_ID=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 8 | head -n 1)
+    TRAVIS_FOLD_NAME=$1
+    echo -e "\e[0Ktraivs_fold:start:$TRAVIS_FOLD_NAME"
+    echo -e "\e[0Ktraivs_time:start:$TRAVIS_TIME_ID"
+    set -x
+}
+function travis_time_end {
+    set +x
+    _COLOR=${1:-32}
+    TRAVIS_END_TIME=$(date +%s%N)
+    TIME_ELAPSED_SECONDS=$(( ($TRAVIS_END_TIME - $TRAVIS_START_TIME)/1000000000 ))
+    echo -e "traivs_time:end:$TRAVIS_TIME_ID:start=$TRAVIS_START_TIME,finish=$TRAVIS_END_TIME,duration=$(($TRAVIS_END_TIME - $TRAVIS_START_TIME))\n\e[0K"
+    echo -e "traivs_fold:end:$TRAVIS_FOLD_NAME"
+    echo -e "\e[0K\e[${_COLOR}mFunction $TRAVIS_FOLD_NAME takes $(( $TIME_ELAPSED_SECONDS / 60 )) min $(( $TIME_ELAPSED_SECONDS % 60 )) sec\e[0m"
+    set -x
+}
+
+travis_time_start setup_apt_sources
+
+apt-get update -qq && apt-get install -y -q wget sudo lsb-release # for docker
+
+sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
+wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
+sudo apt-get update -qq || echo Ignore error on apt-get update
+
+travis_time_end
+travis_time_start install_ros
+
+sudo apt-get install -qq -y python-catkin-pkg python-catkin-tools python-pip python-rosdep python-wstool
+sudo apt-get install -qq -y ros-$ROS_DISTRO-ros ros-$ROS_DISTRO-catkin ros-$ROS_DISTRO-common-tutorials ros-$ROS_DISTRO-rospy-tutorials ros-$ROS_DISTRO-actionlib-tutorials
+sudo apt-get install -qq -y ros-$ROS_DISTRO-rosbridge-server ros-$ROS_DISTRO-tf2-web-republisher
+source /opt/ros/$ROS_DISTRO/setup.bash
+
+travis_time_end
+# https://docs.travis-ci.com/user/gui-and-headless-browsers/
+# travis_time_start start_xfvb
+
+# # Set up Xfvb for Firefox headless testing
+# export DISPLAY=:99.0
+# sh -e /etc/init.d/xvfb start
+
+# travis_time_end
+travis_time_start setup_catkin_workspace
+
+# Setup Catkin workspace
+mkdir -p ~/catkin_ws/src
+cd ~/catkin_ws && catkin init
+wstool init src
+wstool merge -t src ${CI_SOURCE_PATH}/.rosinstall
+wstool update -t src
+ln -s $CI_SOURCE_PATH src/${REPOSITORY_NAME}
+ls -al src/
+wstool info -t src
+
+travis_time_end
+travis_time_start rosdep_init_update
+
+sudo rosdep init || sudo rosdep init
+rosdep update
+rosdep install --from-paths src --ignore-src --rosdistro $ROS_DISTRO -r -y -n
+
+travis_time_end
+travis_time_start catkin_build
+
+catkin build
+source devel/setup.bash
+
+travis_time_end

--- a/.travis.sh
+++ b/.travis.sh
@@ -24,7 +24,8 @@ function travis_time_end {
 
 travis_time_start setup_apt_sources
 
-apt-get update -qq && apt-get install -y -q wget sudo lsb-release # for docker
+apt-get update -qq && apt-get install -y -q wget sudo lsb-release gnupg # for docker
+DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata # https://stackoverflow.com/questions/44331836/apt-get-install-tzdata-noninteractive
 
 sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
 wget http://packages.ros.org/ros.key -O - | sudo apt-key add -

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ env:
   matrix:
     - ROS_DISTRO=indigo  DOCKER_IMAGE=ubuntu:trusty
     - ROS_DISTRO=kinetic DOCKER_IMAGE=ubuntu:xenial
+    - ROS_DISTRO=melodic DOCKER_IMAGE=ubuntu:bionic
 sudo: required
 language: node_js
 services:
@@ -14,6 +15,8 @@ branches:
 dist: xenial
 matrix:
   fast_finish: true
+  allow_failures:
+    - env: ROS_DISTRO=melodic DOCKER_IMAGE=ubuntu:bionic
 before_script:
   - export CI_SOURCE_PATH=$(pwd)
   - export REPOSITORY_NAME=${PWD##*/}

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,51 +2,27 @@ env:
   global:
     - PUBLISHED_DIR=public
   matrix:
-    - ROS_DISTRO=indigo
-    - ROS_DISTRO=jade
-    - ROS_DISTRO=kinetic
+    - ROS_DISTRO=indigo  DOCKER_IMAGE=ubuntu:trusty
+    - ROS_DISTRO=kinetic DOCKER_IMAGE=ubuntu:xenial
 sudo: required
-dist: trusty
 language: node_js
+services:
+  - docker
 branches:
   except:
     - master
+dist: xenial
 matrix:
   fast_finish: true
-  allow_failures:
-    - env: ROS_DISTRO=kinetic
 before_script:
-  # Force travis to use its minimal image with default Python settings
-  - sudo rm -fr /opt/python/
-  - export DEBIAN_FRONTEND=noninteractive
   - export CI_SOURCE_PATH=$(pwd)
   - export REPOSITORY_NAME=${PWD##*/}
-  - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
-  - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
-  - sudo apt-get update -qq || echo Ignore error on apt-get update
-  - sudo apt-get install -qq -y python-catkin-pkg python-catkin-tools python-rosdep python-wstool
-  - sudo apt-get install -qq -y ros-$ROS_DISTRO-ros ros-$ROS_DISTRO-catkin ros-$ROS_DISTRO-common-tutorials ros-$ROS_DISTRO-rospy-tutorials ros-$ROS_DISTRO-actionlib-tutorials
-  - sudo apt-get install -qq -y ros-$ROS_DISTRO-rosbridge-server ros-$ROS_DISTRO-tf2-web-republisher
-  - source /opt/ros/$ROS_DISTRO/setup.bash
-  # Set up Xfvb for Firefox headless testing
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
-  # Setup Catkin workspace
-  - mkdir -p ~/catkin_ws/src
-  - cd ~/catkin_ws && catkin init
-  - wstool init src
-  - wstool merge -t src ${CI_SOURCE_PATH}/.rosinstall
-  - wstool update -t src
-  - ln -s $CI_SOURCE_PATH src/${REPOSITORY_NAME}
-  - ls -al src/
-  - wstool info -t src
-  - sudo rosdep init || sudo rosdep init
-  - rosdep update
-  - rosdep install --from-paths src --ignore-src --rosdistro $ROS_DISTRO -r -y -n
+  - echo "Testing branch $TRAVIS_BRANCH of $REPOSITORY_NAME from $CI_SOURCE_PATH"
 script:
-  - catkin build
-  - source devel/setup.bash
+  - docker run --rm -i -v $CI_SOURCE_PATH:$CI_SOURCE_PATH -e "CI_SOURCE_PATH=$CI_SOURCE_PATH" -e "HOME=$HOME" -e "ROS_DISTRO=$ROS_DISTRO" -t $DOCKER_IMAGE sh -c "cd $CI_SOURCE_PATH; ./.travis.sh"
 after_success:
+  - sudo apt-get update -qq || echo "Ignore error on apt-get update"
+  - sudo apt-get install -qq -y catkin # .deploy.sh needs catkin_topological_order
   - $CI_SOURCE_PATH/.deploy.sh
   - cd $CI_SOURCE_PATH  # This is for deploy section
 deploy:
@@ -58,4 +34,5 @@ deploy:
   keep_history: false
   on:
     branch: kinetic-devel  # set to default branch
-    condition: "$ROS_DISTRO = indigo"
+    condition: "$ROS_DISTRO = kinetic"
+


### PR DESCRIPTION
- .travis.yml : use docker to run scripts

melodic still fails
```
[1m[31m_______________________________________________________________________________[0m[0m
[1m[31mErrors[0m    [31m <<[0m [36mrwt_image_view[0m:[34mcmake[0m [1m[31m/home/travis/catkin_ws/logs/rwt_image_view/build.cmake.000.log[0m[0m
[31m[1mCMake Error[0m at /opt/ros/melodic/share/catkin/cmake/catkinConfig.cmake:83 (find_package):

  Could not find a package configuration file provided by "roswww" with any

  of the following names:



    roswwwConfig.cmake

    roswww-config.cmake



  Add the installation prefix of "roswww" to CMAKE_PREFIX_PATH or set

  "roswww_DIR" to a directory containing one of the above files.  If "roswww"

  provides a separate development package or SDK, be sure it has been

  installed.

[36mCall Stack (most recent call first):[0m

  CMakeLists.txt:4 (find_package)





[1m[30mcd /home/travis/catkin_ws/build/rwt_image_view; catkin build --get-env rwt_image_view | catkin env -si  /usr/bin/cmake /home/travis/catkin_ws/src/visualization_rwt/rwt_image_view --no-warn-unused-cli -DCATKIN_DEVEL_PREFIX=/home/travis/catkin_ws/devel/.private/rwt_image_view -DCMAKE_INSTALL_PREFIX=/home/travis/catkin_ws/install; cd -[0m
[0m
[31m...............................................................................[0m[0m
[1m[31mFailed[0m    [31m <<[0m [36mrwt_image_view[0m:[34mcmake                  [0m[ [33mExited with code [1m[33m1[0m ][0m     
[1m[31mFailed[0m    [31m<<<[0m [36mrwt_image_view                       [0m [ [33m2.9 seconds[0m ][0m            
[1m[31mAbandoned[0m [31m<<<[0m [36mrwt_plot                             [0m [ [33mUnrelated job failed[0m[0m ][0m   
[1m[31mAbandoned[0m [31m<<<[0m [36mrwt_speech_recognition               [0m [ [33mUnrelated job failed[0m[0m ][0m   
[1m[31mAbandoned[0m [31m<<<[0m [36mrwt_robot_monitor                    [0m [ [33mUnrelated job failed[0m[0m ][0m   
[[35mbuild[0m - [33m18.3[0m] [[1m[32m10[0m/[32m14[0m complete] [[1m[32m1[0m/[32m2[0m jobs] [[1m[30m0[0m queued][0m [[1m[31m1[0m [31mfailed[0m][0m [[36mrwt_movei[0m[0m... 
[1m[31m_______________________________________________________________________________[0m[0m
[1m[31mErrors[0m    [31m <<[0m [36mrwt_moveit[0m:[34mcmake[0m [1m[31m/home/travis/catkin_ws/logs/rwt_moveit/build.cmake.000.log[0m[0m
[31m[1mCMake Error[0m at /opt/ros/melodic/share/catkin/cmake/catkinConfig.cmake:83 (find_package):

  Could not find a package configuration file provided by

  "interactive_marker_proxy" with any of the following names:



    interactive_marker_proxyConfig.cmake

    interactive_marker_proxy-config.cmake



  Add the installation prefix of "interactive_marker_proxy" to

  CMAKE_PREFIX_PATH or set "interactive_marker_proxy_DIR" to a directory

  containing one of the above files.  If "interactive_marker_proxy" provides

  a separate development package or SDK, be sure it has been installed.

[36mCall Stack (most recent call first):[0m

  CMakeLists.txt:4 (find_package)





[1m[30mcd /home/travis/catkin_ws/build/rwt_moveit; catkin build --get-env rwt_moveit | catkin env -si  /usr/bin/cmake /home/travis/catkin_ws/src/visualization_rwt/rwt_moveit --no-warn-unused-cli -DCATKIN_DEVEL_PREFIX=/home/travis/catkin_ws/devel/.private/rwt_moveit -DCMAKE_INSTALL_PREFIX=/home/travis/catkin_ws/install; cd -[0m
[0m
```
