### PR TITLE
Register app running user name in rwt_app_chooser

### DIFF
--- a/rwt_app_chooser/www/components/add_robot.html
+++ b/rwt_app_chooser/www/components/add_robot.html
@@ -56,8 +56,8 @@
      var rs = load_robots();
      for (var r of rs) {
        if (r.name == name) {
-         var prompt = phonon.alert("Robot " + name + " is already registered", "Error");
-         prompt.on("confirm", function() {});
+         var alert = phonon.alert("Robot " + name + " is already registered", "Error");
+         alert.on("confirm", function() {});
          return false;
        }
      }

--- a/rwt_app_chooser/www/components/robot.html
+++ b/rwt_app_chooser/www/components/robot.html
@@ -73,13 +73,13 @@
    });
 
    document.querySelector("#clear").on("tap", function() {
-     var prompt = phonon.prompt("Are you sure to remove all robots from the list?", "Clear");
-     prompt.on("confirm", function(value) {
+     var confirm = phonon.confirm("Are you sure to remove all robots from the list?", "Clear");
+     confirm.on("confirm", function() {
        robots = [];
        render_list();
        phonon.notif("Cleared all robots", 3000, false, false);
      });
-     prompt.on("cancel", function() {
+     confirm.on("cancel", function() {
        phonon.notif("Canceled removing the list", 3000, false, false);
      });
    });

--- a/rwt_app_chooser/www/components/task.html
+++ b/rwt_app_chooser/www/components/task.html
@@ -73,8 +73,8 @@
      item.on('tap', function() {
        var that = this;
        if (this.running) {
-         var prompt = phonon.prompt("Shutdown " + this.display_name + "?", "Kill application");
-         prompt.on("confirm", function(value) {
+         var confirm = phonon.confirm("Shutdown " + that.display_name + "?", "Kill application");
+         confirm.on("confirm", function() {
            stop_app(that.name, function(res) {
              console.log("stop_app", res);
              if (res.stopped) {
@@ -85,8 +85,8 @@
            });
          });
        } else {
-         var prompt = phonon.prompt("Launch " + this.display_name + "?", "Launch application");
-         prompt.on("confirm", function(value) {
+         var confirm = phonon.confirm("Launch " + this.display_name + "?", "Launch application");
+         confirm.on("confirm", function() {
            start_app(that.name, function(res) {
              console.log("start_app", res);
              if (res.started) {

--- a/rwt_app_chooser/www/components/task.html
+++ b/rwt_app_chooser/www/components/task.html
@@ -20,6 +20,7 @@
  var robot_uri = null;
  var ros = null;
  var app_list_sub = null;
+ var running_user_name = null;
 
  var start_app = function(name, cb) {
    var srv_name = '/' + robot_name + '/start_app';
@@ -53,6 +54,38 @@
    }
  };
 
+ var get_running_user_name = function(next) {
+   var param = new ROSLIB.Param({
+     ros: ros,
+     name: "/app_manager/running_user_name",
+   });
+   param.get(function(value) {
+     console.log("Getting param: /app_manager/running_user_name " + value);
+     running_user_name = value;
+     next();
+   });
+ }
+
+ var set_running_user_name = function(param_value) {
+   var param = new ROSLIB.Param({
+     ros: ros,
+     name: "/app_manager/running_user_name",
+   });
+   console.log("Setting param: /app_manager/running_user_name " + param_value);
+   param.set(param_value);
+   running_user_name = param_value;
+ }
+
+ var delete_running_user_name = function(param_name) {
+   var param = new ROSLIB.Param({
+     ros: ros,
+     name: "/app_manager/running_user_name",
+   });
+   console.log("Deleting param: /app_manager/running_user_name");
+   param.delete();
+   running_user_name = null;
+ }
+
  var render_app_list = function(apps) {
    clear_app_list();
    var parent = document.querySelector("#app-list");
@@ -75,6 +108,8 @@
        if (this.running) {
          var confirm = phonon.confirm("Shutdown " + that.display_name + "?", "Kill application");
          confirm.on("confirm", function() {
+           console.log("unregister app user name");
+           delete_running_user_name();
            stop_app(that.name, function(res) {
              console.log("stop_app", res);
              if (res.stopped) {
@@ -85,15 +120,23 @@
            });
          });
        } else {
-         var confirm = phonon.confirm("Launch " + this.display_name + "?", "Launch application");
-         confirm.on("confirm", function() {
-           start_app(that.name, function(res) {
-             console.log("start_app", res);
-             if (res.started) {
-               phonon.notif("Launched " + that.display_name, 3000, false, false);
-             } else {
-               phonon.notif(res.message + " (" + res.error_code + ")", 3000, false, false);
-             }
+         var prompt = phonon.prompt("Please fill your user name.", "Register user name");
+         prompt.on("confirm", function(value) {
+           var user_name = String(value);
+           if (user_name.length > 0) {
+             console.log("register app user name: " + user_name);
+             set_running_user_name(user_name);
+           }
+           var confirm = phonon.confirm("Launch " + that.display_name + "?", "Launch application");
+           confirm.on("confirm", function() {
+             start_app(that.name, function(res) {
+               console.log("start_app", res);
+               if (res.started) {
+                 phonon.notif("Launched " + that.display_name, 3000, false, false);
+               } else {
+                 phonon.notif(res.message + " (" + res.error_code + ")", 3000, false, false);
+               }
+             });
            });
          });
        }
@@ -174,19 +217,26 @@
      console.log("subscribing: " + list_name);
 
      app_list_sub.subscribe(function(msg) {
-       console.log("subscribe");
-       var apps = [];
-       msg.available_apps.forEach(function(app) {
-         if (msg.running_apps.find(function(e) {
-           return e.name == app.name;
-         })) {
-           app["running"] = true;
-         } else {
-           app["running"] = false;
+       get_running_user_name(function() {
+         console.log("subscribe");
+         var apps = [];
+         var running = false;
+         msg.available_apps.forEach(function(app) {
+           if (msg.running_apps.find(function(e) {
+             return e.name == app.name;
+           })) {
+             app["running"] = true;
+             running = true;
+           } else {
+             app["running"] = false;
+           }
+           apps.push(app);
+         });
+         if (!running && running_user_name) {
+           delete_running_user_name();
          }
-         apps.push(app);
+         render_app_list(apps);
        });
-       render_app_list(apps);
      });
    });
  };


### PR DESCRIPTION
This PR enables us to register `/app_manager/running_user_name` param before running app.

First, we can register user name for app running.
We can start apps with empty string, but `/app_manager/running_user_name` param will not be set.
![rwt_app_chooser_register_user_name](https://user-images.githubusercontent.com/9300063/99572011-6a3e1500-2a17-11eb-8b0e-b0983065462c.png)

Then, we can run an app.
![rwt_app_chooser_launch](https://user-images.githubusercontent.com/9300063/99572009-690ce800-2a17-11eb-8760-6217ee57bfe6.png)

cc. @k-okada