### PR TITLE
[rwt_robot_monitor] use websocket_port 9090 as default in rwt_robot_monitor

### DIFF
--- a/rwt_robot_monitor/launch/example.launch
+++ b/rwt_robot_monitor/launch/example.launch
@@ -1,11 +1,16 @@
 <launch>
   <arg name="launch_roswww" default="true" />
+  <arg name="launch_websocket" default="true" />
+  <arg name="roswww_port" default="8000" />
+  <arg name="websocket_port" default="9090" />
+
   <include file="$(find roswww)/launch/roswww.launch"
            if="$(arg launch_roswww)">
-    <arg name="port" value="8000" />
+    <arg name="port" value="$(arg roswww_port)" />
   </include>
 
-  <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch">
-    <arg name="port" value="8888" />
+  <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch"
+           if="$(arg launch_websocket)">
+    <arg name="port" value="$(arg websocket_port)" />
   </include>
 </launch>


### PR DESCRIPTION
use `9090` as default in rwt_robot_monitor