### PR TITLE
use websocket_port 9090 as defaut

### DIFF
--- a/rwt_app_chooser/test/test_rwt_app_chooser.py
+++ b/rwt_app_chooser/test/test_rwt_app_chooser.py
@@ -139,12 +139,20 @@ class TestRwtAppChooser(unittest.TestCase):
 
         # Select Task
         self.wait.until(EC.presence_of_element_located((By.CSS_SELECTOR, "span[class='Title']")))
-        task_text = self.browser.find_element_by_css_selector("span[class='Title']")
+        task_texts = self.browser.find_elements_by_css_selector("span[class='Title']")
+        while len(task_texts) != 5:
+            task_texts = self.browser.find_elements_by_css_selector("span[class='Title']")
+            time.sleep(1)
+        task_text = task_texts[-1]
         self.assertIsNotNone(task_text, "Object span[class='Title']")
-        self.assertTrue(u'Hello World' in task_text.text)
+        self.assertTrue(u'Hello World' in task_text.text, "Hello World is not found in {}".format(task_text))
 
         self.wait.until(EC.presence_of_element_located((By.CSS_SELECTOR, "div[class='column large-1 tablet-3 phone-6']")))
-        task_image = self.browser.find_element_by_css_selector("div[class='column large-1 tablet-3 phone-6']")
+        task_images = self.browser.find_elements_by_css_selector("div[class='column large-1 tablet-3 phone-6']")
+        while len(task_images) != 5:
+            task_images = self.browser.find_elements_by_css_selector("div[class='column large-1 tablet-3 phone-6']")
+            time.sleep(1)
+        task_image = task_images[-1]
         self.assertIsNotNone(task_image, "Object div[class='column large-1 tablet-3 phone-6']")
         task_image.click()
         rospy.logwarn("Selected {} task".format(task_text.text))

--- a/rwt_app_chooser/test/test_rwt_app_chooser.py
+++ b/rwt_app_chooser/test/test_rwt_app_chooser.py
@@ -34,6 +34,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
+import argparse
 import sys
 import time
 import rospy
@@ -62,6 +63,11 @@ class TestRwtAppChooser(unittest.TestCase):
         rospy.init_node('test_rwt_app_chooser')
 
     def setUp(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--no-headless', action='store_true',
+                            help='start webdriver with headless mode')
+        args, unknown = parser.parse_known_args()
+
         self.robotsound_msg = None
         self.robotsound_msg_received = 0
 
@@ -69,7 +75,8 @@ class TestRwtAppChooser(unittest.TestCase):
         self.url_base = rospy.get_param("url_roswww_testserver")
 
         opts = webdriver.firefox.options.Options()
-        opts.add_argument('-headless')
+        if not args.no_headless:
+            opts.add_argument('-headless')
         self.browser = webdriver.Firefox(options=opts)
 
         self.wait = webdriver.support.ui.WebDriverWait(self.browser, 10)

--- a/rwt_app_chooser/test/test_rwt_app_chooser.py
+++ b/rwt_app_chooser/test/test_rwt_app_chooser.py
@@ -131,30 +131,18 @@ class TestRwtAppChooser(unittest.TestCase):
         self.assertIsNotNone(select_robot, "Object div[class='item-content']/span[class='title']")
         self.assertTrue(u'pr1012' in select_robot.text)
         rospy.logwarn("Selected {} robot".format(select_robot.text))
-        
+
         self.wait.until(EC.presence_of_element_located((By.CSS_SELECTOR, "li[class='item-expanded robot-list-item']")))
         select = self.browser.find_element_by_css_selector("li[class='item-expanded robot-list-item']")
         self.assertIsNotNone(select, "Object li[class='item-expanded robot-list-item']")
         select.click()
 
         # Select Task
-        self.wait.until(EC.presence_of_element_located((By.CSS_SELECTOR, "span[class='Title']")))
-        task_texts = self.browser.find_elements_by_css_selector("span[class='Title']")
-        while len(task_texts) != 5:
-            task_texts = self.browser.find_elements_by_css_selector("span[class='Title']")
-            time.sleep(1)
-        task_text = task_texts[-1]
+        self.wait.until(EC.presence_of_element_located((By.XPATH, "//div/span[@class='Title' and contains(text(), 'Hello World')]")))
+        task_text = self.browser.find_element_by_xpath("//div/span[@class='Title' and contains(text(), 'Hello World')]")
         self.assertIsNotNone(task_text, "Object span[class='Title']")
         self.assertTrue(u'Hello World' in task_text.text, "Hello World is not found in {}".format(task_text))
-
-        self.wait.until(EC.presence_of_element_located((By.CSS_SELECTOR, "div[class='column large-1 tablet-3 phone-6']")))
-        task_images = self.browser.find_elements_by_css_selector("div[class='column large-1 tablet-3 phone-6']")
-        while len(task_images) != 5:
-            task_images = self.browser.find_elements_by_css_selector("div[class='column large-1 tablet-3 phone-6']")
-            time.sleep(1)
-        task_image = task_images[-1]
-        self.assertIsNotNone(task_image, "Object div[class='column large-1 tablet-3 phone-6']")
-        task_image.click()
+        task_text.click()
         rospy.logwarn("Selected {} task".format(task_text.text))
 
         # input user name

--- a/rwt_app_chooser/test/test_rwt_app_chooser.test
+++ b/rwt_app_chooser/test/test_rwt_app_chooser.test
@@ -1,4 +1,7 @@
 <launch>
+  <arg name="gui" default="false"/>
+  <arg name="test_option" default="--no-headless" if="$(arg gui)" />
+  <arg name="test_option" default="" unless="$(arg gui)" />
   <arg name="port" default="8000"/> <!-- avoid to use apache default port -->
 
   <include file="$(find rwt_app_chooser)/sample/launch/sample.launch">
@@ -6,6 +9,6 @@
   <param name='url_roswww_testserver' value='http://localhost:$(arg port)' />
 
   <test type="test_rwt_app_chooser.py" pkg="rwt_app_chooser" test-name="test_rwt_app_chooser"
-        time-limit="100" retry="3" args="" />
+        time-limit="100" retry="3" args="$(arg test_option)" />
 
 </launch>

--- a/rwt_image_view/launch/rwt_image_view.launch
+++ b/rwt_image_view/launch/rwt_image_view.launch
@@ -6,7 +6,7 @@
   </include>
 
   <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch" >
-    <arg name="port" value="8888" />
+    <arg name="port" value="9090" />
   </include>
   <node pkg="web_video_server" type="web_video_server"
         name="web_video_server"

--- a/rwt_image_view/launch/rwt_image_view.launch
+++ b/rwt_image_view/launch/rwt_image_view.launch
@@ -1,19 +1,26 @@
 <launch>
   <arg name="launch_roswww" default="true" />
+  <arg name="launch_websocket" default="true" />
+  <arg name="roswww_port" default="8000" />
+  <arg name="websocket_port" default="9090" />
+  <arg name="web_video_server_port" default="8080" />
+  <arg name="web_video_server_address" default="127.0.0.1" />
+
   <include file="$(find roswww)/launch/roswww.launch"
            if="$(arg launch_roswww)">
-    <arg name="port" value="8000" />
+    <arg name="port" value="$(arg roswww_port)" />
   </include>
 
-  <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch" >
-    <arg name="port" value="9090" />
+  <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch"
+           if="$(arg launch_websocket)">
+    <arg name="port" value="$(arg websocket_port)" />
   </include>
   <node pkg="web_video_server" type="web_video_server"
         name="web_video_server"
         output="screen"
         clear_params="true">
-   <param name="port" value="8080" />
-   <param name="address" value="127.0.0.1" />
+   <param name="port" value="$(arg web_video_server_port)" />
+   <param name="address" value="$(arg web_video_server_address)" />
   </node>
   <node pkg="rwt_image_view" type="rosbag_record_server.py"
         name="rosbag_record_server"

--- a/rwt_image_view/test/test_rwt_image_view.py
+++ b/rwt_image_view/test/test_rwt_image_view.py
@@ -90,7 +90,7 @@ class TestRwtImageView(unittest.TestCase):
         uri = self.browser.find_element_by_id("input-ros-master-uri")
         self.assertIsNotNone(uri, "Object id=input-ros-master-uri not found")
         uri.clear();
-        uri.send_keys('ws://localhost:8888/')
+        uri.send_keys('ws://localhost:9090/')
 
         self.wait.until(EC.presence_of_element_located((By.ID, "button-ros-master-connect")))
         connect = self.browser.find_element_by_id("button-ros-master-connect")

--- a/rwt_image_view/test/test_rwt_image_view.py
+++ b/rwt_image_view/test/test_rwt_image_view.py
@@ -34,6 +34,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
+import argparse
 import sys
 import time
 import rospy
@@ -50,10 +51,16 @@ CLASSNAME = 'rwt_image_view'
 class TestRwtImageView(unittest.TestCase):
 
     def setUp(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--no-headless', action='store_true',
+                            help='start webdriver with headless mode')
+        args, unknown = parser.parse_known_args()
+
         self.url_base = rospy.get_param("url_roswww_testserver")
 
         opts = webdriver.firefox.options.Options()
-        opts.add_argument('-headless')
+        if not args.no_headless:
+            opts.add_argument('-headless')
         self.browser = webdriver.Firefox(options=opts)
 
         self.wait = webdriver.support.ui.WebDriverWait(self.browser, 10)

--- a/rwt_image_view/test/test_rwt_image_view.test
+++ b/rwt_image_view/test/test_rwt_image_view.test
@@ -1,4 +1,7 @@
 <launch>
+  <arg name="gui" default="false"/>
+  <arg name="test_option" default="--no-headless" if="$(arg gui)" />
+  <arg name="test_option" default="" unless="$(arg gui)" />
   <arg name="port" default="8000"/> <!-- avoid to use apache default port -->
 
   <node pkg="image_publisher" type="image_publisher" name="image_publisher"
@@ -9,6 +12,6 @@
   <param name='url_roswww_testserver' value='http://localhost:$(arg port)' />
 
   <test type="test_rwt_image_view.py" pkg="rwt_image_view" test-name="test_rwt_image_view"
-        time-limit="100" args="" />
+        time-limit="100" args="$(arg test_option)" />
 
 </launch>

--- a/rwt_image_view/www/index.html
+++ b/rwt_image_view/www/index.html
@@ -31,9 +31,9 @@
       <div id="canvas-area"></div>
     </div>
 
-    <div id="debug-text-area1">text1</div>
-    <div id="debug-text-area2">text2</div>
-    <div id="debug-text-area3">text3</div>
+    <div id="debug-text-area1">mousemove (pos.x, pos.y)</div>
+    <div id="debug-text-area2">screenpoint (pos.x, pos.y)</div>
+    <div id="debug-text-area3">camera (width x height)</div>
     
     <!-- <script type="text/javascript" src="/rwt_utils_3rdparty/jquery/jquery.min.js"></script> -->
     <script type="text/javascript" src="/rwt_utils_3rdparty/jquery.min.js"></script>

--- a/rwt_nav/README.md
+++ b/rwt_nav/README.md
@@ -13,7 +13,7 @@ for example : `http://localhost:8000/rwt_nav/`
 To view live location of robot :
 
 ```bash
-rosrun robot_pose_publisher robot_pose_publisher
+rosrun rwt_nav robot_pose_publisher
 ```
 
 - Current position of the robot is shown by yellow arrow.

--- a/rwt_nav/package.xml
+++ b/rwt_nav/package.xml
@@ -23,7 +23,6 @@
   <build_depend>roscpp</build_depend>
   <build_depend>tf</build_depend>
 
-  <run_depend>robot_pose_publisher</run_depend>
   <run_depend>rosbridge_server</run_depend>
   <run_depend>rwt_utils_3rdparty</run_depend>
   <run_depend>web_video_server</run_depend>

--- a/rwt_nav/test/test_rwt_nav.py
+++ b/rwt_nav/test/test_rwt_nav.py
@@ -34,6 +34,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
+import argparse
 import sys
 import time
 import rospy
@@ -62,6 +63,11 @@ class TestRwtNav(unittest.TestCase):
         rospy.init_node('test_rwt_nav')
 
     def setUp(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--no-headless', action='store_true',
+                            help='start webdriver with headless mode')
+        args, unknown = parser.parse_known_args()
+
         self.goal_msg = None
         self.goal_msg_received = 0
 
@@ -69,7 +75,8 @@ class TestRwtNav(unittest.TestCase):
         self.url_base = rospy.get_param("url_roswww_testserver")
 
         opts = webdriver.firefox.options.Options()
-        opts.add_argument('-headless')
+        if not args.no_headless:
+            opts.add_argument('-headless')
         self.browser = webdriver.Firefox(options=opts)
 
         self.wait = webdriver.support.ui.WebDriverWait(self.browser, 10)

--- a/rwt_nav/test/test_rwt_nav.test
+++ b/rwt_nav/test/test_rwt_nav.test
@@ -1,4 +1,7 @@
 <launch>
+  <arg name="gui" default="false"/>
+  <arg name="test_option" default="--no-headless" if="$(arg gui)" />
+  <arg name="test_option" default="" unless="$(arg gui)" />
   <arg name="port" default="8000"/> <!-- avoid to use apache default port -->
 
   <node pkg="image_publisher" type="image_publisher" name="image_publisher"
@@ -11,6 +14,6 @@
   <param name='url_roswww_testserver' value='http://localhost:$(arg port)' />
 
   <test type="test_rwt_nav.py" pkg="rwt_nav" test-name="test_rwt_nav"
-        time-limit="100" args="" />
+        time-limit="100" args="$(arg test_option)" />
 
 </launch>

--- a/rwt_plot/launch/rwt_plot.launch
+++ b/rwt_plot/launch/rwt_plot.launch
@@ -1,11 +1,16 @@
 <launch>
   <arg name="launch_roswww" default="true" />
+  <arg name="launch_websocket" default="true" />
+  <arg name="roswww_port" default="8000" />
+  <arg name="websocket_port" default="9090" />
+
   <group if="$(arg launch_roswww)">
     <include file="$(find roswww)/launch/roswww.launch">
-      <arg name="port" value="8000" />
+      <arg name="port" value="$(arg roswww_port)" />
     </include>
   </group>
-  <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch">
-    <arg name="port" value="8888" />
+  <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch"
+           if="$(arg launch_websocket)">
+    <arg name="port" value="$(arg websocket_port)" />
   </include>
 </launch>

--- a/rwt_plot/test/test_rwt_plot.py
+++ b/rwt_plot/test/test_rwt_plot.py
@@ -34,6 +34,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
+import argparse
 import sys
 import time
 import rospy
@@ -61,6 +62,11 @@ class TestRwtPlot(unittest.TestCase):
         rospy.init_node('test_rwt_plot')
 
     def setUp(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--no-headless', action='store_true',
+                            help='start webdriver with headless mode')
+        args, unknown = parser.parse_known_args()
+
         self.sin_msg = None
         self.sin_msg_received = 0
 
@@ -68,7 +74,8 @@ class TestRwtPlot(unittest.TestCase):
         self.url_base = rospy.get_param("url_roswww_testserver")
 
         opts = webdriver.firefox.options.Options()
-        opts.add_argument('-headless')
+        if not args.no_headless:
+            opts.add_argument('-headless')
         self.browser = webdriver.Firefox(options=opts)
 
         self.wait = webdriver.support.ui.WebDriverWait(self.browser, 10)

--- a/rwt_plot/test/test_rwt_plot.py
+++ b/rwt_plot/test/test_rwt_plot.py
@@ -105,7 +105,7 @@ class TestRwtPlot(unittest.TestCase):
         uri = self.browser.find_element_by_id("input-ros-master-uri")
         self.assertIsNotNone(uri, "Object id=input-ros-master-uri not found")
         uri.clear();
-        uri.send_keys('ws://localhost:8888/')
+        uri.send_keys('ws://localhost:9090/')
 
         self.wait.until(EC.presence_of_element_located((By.ID, "button-ros-master-connect")))
         connect = self.browser.find_element_by_id("button-ros-master-connect")

--- a/rwt_plot/test/test_rwt_plot.test
+++ b/rwt_plot/test/test_rwt_plot.test
@@ -1,4 +1,7 @@
 <launch>
+  <arg name="gui" default="false"/>
+  <arg name="test_option" default="--no-headless" if="$(arg gui)" />
+  <arg name="test_option" default="" unless="$(arg gui)" />
   <arg name="port" default="8000"/> <!-- avoid to use apache default port -->
 
   <include file="$(find rwt_plot)/launch/example.launch">
@@ -6,6 +9,6 @@
   <param name='url_roswww_testserver' value='http://localhost:$(arg port)' />
 
   <test type="test_rwt_plot.py" pkg="rwt_plot" test-name="test_rwt_plot"
-        time-limit="100" args="" />
+        time-limit="100" args="$(arg test_option)" />
 
 </launch>

--- a/rwt_robot_monitor/launch/example.launch
+++ b/rwt_robot_monitor/launch/example.launch
@@ -1,11 +1,16 @@
 <launch>
   <arg name="launch_roswww" default="true" />
+  <arg name="launch_websocket" default="true" />
+  <arg name="roswww_port" default="8000" />
+  <arg name="websocket_port" default="9090" />
+
   <include file="$(find roswww)/launch/roswww.launch"
            if="$(arg launch_roswww)">
-    <arg name="port" value="8000" />
+    <arg name="port" value="$(arg roswww_port)" />
   </include>
 
-  <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch">
-    <arg name="port" value="8888" />
+  <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch"
+           if="$(arg launch_websocket)">
+    <arg name="port" value="$(arg websocket_port)" />
   </include>
 </launch>

--- a/rwt_robot_monitor/test/test_rwt_robot_monitor.py
+++ b/rwt_robot_monitor/test/test_rwt_robot_monitor.py
@@ -34,6 +34,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
+import argparse
 import sys
 import time
 import rospy
@@ -61,6 +62,11 @@ class TestRwtRobotMonitor(unittest.TestCase):
         rospy.init_node('test_rwt_robot_monitor')
 
     def setUp(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--no-headless', action='store_true',
+                            help='start webdriver with headless mode')
+        args, unknown = parser.parse_known_args()
+
         self.sin_msg = None
         self.sin_msg_received = 0
 
@@ -68,7 +74,8 @@ class TestRwtRobotMonitor(unittest.TestCase):
         self.url_base = rospy.get_param("url_roswww_testserver")
 
         opts = webdriver.firefox.options.Options()
-        opts.add_argument('-headless')
+        if not args.no_headless:
+            opts.add_argument('-headless')
         self.browser = webdriver.Firefox(options=opts)
 
         self.wait = webdriver.support.ui.WebDriverWait(self.browser, 10)

--- a/rwt_robot_monitor/test/test_rwt_robot_monitor.py
+++ b/rwt_robot_monitor/test/test_rwt_robot_monitor.py
@@ -99,7 +99,7 @@ class TestRwtRobotMonitor(unittest.TestCase):
         uri = self.browser.find_element_by_id("input-ros-master-uri")
         self.assertIsNotNone(uri, "Object id=input-ros-master-uri not found")
         uri.clear();
-        uri.send_keys('ws://localhost:8888/')
+        uri.send_keys('ws://localhost:9090/')
 
         self.wait.until(EC.presence_of_element_located((By.ID, "button-ros-master-connect")))
         connect = self.browser.find_element_by_id("button-ros-master-connect")

--- a/rwt_robot_monitor/test/test_rwt_robot_monitor.test
+++ b/rwt_robot_monitor/test/test_rwt_robot_monitor.test
@@ -1,4 +1,7 @@
 <launch>
+  <arg name="gui" default="false"/>
+  <arg name="test_option" default="--no-headless" if="$(arg gui)" />
+  <arg name="test_option" default="" unless="$(arg gui)" />
   <arg name="port" default="8000"/> <!-- avoid to use apache default port -->
 
   <!-- copied from diagnostic_aggregator/test/launch/test_agg.launch -->
@@ -16,6 +19,6 @@
   <param name='url_roswww_testserver' value='http://localhost:$(arg port)' />
 
   <test type="test_rwt_robot_monitor.py" pkg="rwt_robot_monitor" test-name="test_rwt_robot_monitor"
-        time-limit="100" args="" />
+        time-limit="100" args="$(arg test_option)" />
 
 </launch>

--- a/rwt_speech_recognition/launch/rwt_speech_recognition.launch
+++ b/rwt_speech_recognition/launch/rwt_speech_recognition.launch
@@ -1,11 +1,16 @@
 <launch>
   <arg name="launch_roswww" default="true" />
+  <arg name="launch_websocket" default="true" />
+  <arg name="roswww_port" default="8000" />
+  <arg name="websocket_port" default="9090" />
+
   <include file="$(find roswww)/launch/roswww.launch"
            if="$(arg launch_roswww)">
-    <arg name="port" value="8000" />
+    <arg name="port" value="$(arg roswww_port)" />
   </include>
 
-  <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch">
-    <arg name="port" value="8888" />
+  <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch"
+           if="$(arg launch_websocket)">
+    <arg name="port" value="$(arg websocket_port)" />
   </include>
 </launch>

--- a/rwt_speech_recognition/test/test_rwt_speech_recognition.py
+++ b/rwt_speech_recognition/test/test_rwt_speech_recognition.py
@@ -91,7 +91,7 @@ class TestRwtSpeechRecognition(unittest.TestCase):
         uri = self.browser.find_element_by_id("input-ros-master-uri")
         self.assertIsNotNone(uri, "Object id=input-ros-master-uri not found")
         uri.clear();
-        uri.send_keys('ws://localhost:8888/')
+        uri.send_keys('ws://localhost:9090/')
 
         self.wait.until(EC.presence_of_element_located((By.ID, "button-ros-master-connect")))
         connect = self.browser.find_element_by_id("button-ros-master-connect")

--- a/rwt_speech_recognition/test/test_rwt_speech_recognition.py
+++ b/rwt_speech_recognition/test/test_rwt_speech_recognition.py
@@ -34,6 +34,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
+import argparse
 import sys
 import time
 import rospy
@@ -51,10 +52,16 @@ CLASSNAME = 'rwt_speech_recognition'
 class TestRwtSpeechRecognition(unittest.TestCase):
 
     def setUp(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--no-headless', action='store_true',
+                            help='start webdriver with headless mode')
+        args, unknown = parser.parse_known_args()
+
         self.url_base = rospy.get_param("url_roswww_testserver")
 
         opts = webdriver.firefox.options.Options()
-        opts.add_argument('-headless')
+        if not args.no_headless:
+            opts.add_argument('-headless')
         self.browser = webdriver.Firefox(options=opts)
 
         self.wait = webdriver.support.ui.WebDriverWait(self.browser, 10)

--- a/rwt_speech_recognition/test/test_rwt_speech_recognition.test
+++ b/rwt_speech_recognition/test/test_rwt_speech_recognition.test
@@ -1,4 +1,7 @@
 <launch>
+  <arg name="gui" default="false"/>
+  <arg name="test_option" default="--no-headless" if="$(arg gui)" />
+  <arg name="test_option" default="" unless="$(arg gui)" />
   <arg name="port" default="8000"/> <!-- avoid to use apache default port -->
 
   <include file="$(find rwt_speech_recognition)/launch/rwt_speech_recognition.launch">
@@ -6,6 +9,6 @@
   <param name='url_roswww_testserver' value='http://localhost:$(arg port)' />
 
   <test type="test_rwt_speech_recognition.py" pkg="rwt_speech_recognition" test-name="test_rwt_speech_recognition"
-        time-limit="100" args="" />
+        time-limit="100" args="$(arg test_option)" />
 
 </launch>

--- a/rwt_speech_recognition/www/js/rwt_speech_recognition.main.js
+++ b/rwt_speech_recognition/www/js/rwt_speech_recognition.main.js
@@ -2,7 +2,7 @@ $(function() {
 
   /* ROS */
   var ros = new ROSLIB.Ros();
-  ros.install_config_button("config-button");
+  ros.install_config_button("config-button", true, 9090);
 
   var pub_speech = null;
   var publish = function(msg) {

--- a/rwt_steer/test/test_rwt_steer.py
+++ b/rwt_steer/test/test_rwt_steer.py
@@ -34,6 +34,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
+import argparse
 import sys
 import time
 import rospy
@@ -61,6 +62,11 @@ class TestRwtSteer(unittest.TestCase):
         rospy.init_node('test_rwt_steer')
 
     def setUp(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--no-headless', action='store_true',
+                            help='start webdriver with headless mode')
+        args, unknown = parser.parse_known_args()
+
         self.joy_msg = None
         self.joy_msg_received = 0
 
@@ -68,7 +74,8 @@ class TestRwtSteer(unittest.TestCase):
         self.url_base = rospy.get_param("url_roswww_testserver")
 
         opts = webdriver.firefox.options.Options()
-        opts.add_argument('-headless')
+        if not args.no_headless:
+            opts.add_argument('-headless')
         self.browser = webdriver.Firefox(options=opts)
 
         self.wait = webdriver.support.ui.WebDriverWait(self.browser, 10)

--- a/rwt_steer/test/test_rwt_steer.test
+++ b/rwt_steer/test/test_rwt_steer.test
@@ -1,4 +1,7 @@
 <launch>
+  <arg name="gui" default="false"/>
+  <arg name="test_option" default="--no-headless" if="$(arg gui)" />
+  <arg name="test_option" default="" unless="$(arg gui)" />
   <arg name="port" default="8000"/> <!-- avoid to use apache default port -->
 
   <node pkg="image_publisher" type="image_publisher" name="image_publisher"
@@ -9,6 +12,6 @@
   <param name='url_roswww_testserver' value='http://localhost:$(arg port)' />
 
   <test type="test_rwt_steer.py" pkg="rwt_steer" test-name="test_rwt_steer"
-        time-limit="100" args="" />
+        time-limit="100" args="$(arg test_option)" />
 
 </launch>

--- a/rwt_utils_3rdparty/www/rwt_utils.js
+++ b/rwt_utils_3rdparty/www/rwt_utils.js
@@ -1,4 +1,4 @@
-ROSLIB.Ros.prototype.install_config_button = function(id, auto_connect, port=8888) {
+ROSLIB.Ros.prototype.install_config_button = function(id, auto_connect, port=9090) {
   var auto_connect = typeof auto_connect !== 'undefined' ? auto_connect : true;
   var that = this;
   var parent = document.getElementById(id);

--- a/rwt_utils_3rdparty/www/rwt_utils.js
+++ b/rwt_utils_3rdparty/www/rwt_utils.js
@@ -44,7 +44,8 @@ ROSLIB.Ros.prototype.install_config_button = function(id, auto_connect, port=909
   var label = document.createElement("label");
   li.appendChild(label);
   label.setAttribute("for", "input-ros-master-uri");
-  label.textContent = "ROS Master URI";
+  label.textContent = "Rosbridge WebSocket URI";
+  label.style.fontSize = '12px'
   
   var input = document.createElement("input");
   li.appendChild(input);

--- a/rwt_utils_3rdparty/www/rwt_utils.js
+++ b/rwt_utils_3rdparty/www/rwt_utils.js
@@ -81,6 +81,7 @@ ROSLIB.Ros.prototype.install_config_button = function(id, auto_connect, port=909
       that.close();
     }
     that.connect(e.value);
+    $("#button-ros-master-settings").dropdown("toggle")
   };
 
   // connect with default location


### PR DESCRIPTION
merged version of #106, #105, #104, #103 #102

- use ws://locahost:9090 in test code
-  wait until system actually reads HelloWorld task
- support gui argument
-  now we use robot_pose_publisher compiled in rwt_nav
- use websocket_port 9090 as default in rwt_plot
- use websocket_port 9090 as default in rwt_robot_monitor
- set default websocket port 9090
- set default port as 9090 in rwt_speech_recognition
- add arg and use websocket 9090 port in rwt_speech_recognition
- add args for rwt_image_view.launch
- use websocket port 9090