### PR TITLE
move_base/goal requires frame_id, without starting '/'

### DIFF
--- a/rwt_nav/www/3rdparty/ros/js/nav2d.js
+++ b/rwt_nav/www/3rdparty/ros/js/nav2d.js
@@ -108,7 +108,7 @@ NAV2D.Navigator = function(options) {
       goalMessage : {
         target_pose : {
           header : {
-            frame_id : '/map'
+            frame_id : 'map'
           },
           pose : pose
         }


### PR DESCRIPTION
to fix following error/warning

```
Warning: Invalid argument /map passed to canTransform argument source_frame in tf2 frame_ids cannot start with a '/' like:
         at line 134 in /tmp/binarydeb/ros-melodic-tf2-0.6.5/src/buffer_core.cpp
[ WARN] [1645522151.660224428, 19134.759000000]: Failed to transform the goal pose from /map into the map frame: Invalid argument /map passed to lookupTransform argument source_frame in tf2 frame_ids cannot start with a '/' like:
[ERROR] [1645522151.660344650, 19134.759000000]: The goal pose passed to this planner must be in the map frame.  It is instead in the /map frame.
```
![Screenshot from 2022-02-22 19-48-05](https://user-images.githubusercontent.com/493276/155117257-348961a9-66af-4d4f-9764-04213f9fa05c.png)

![Screenshot from 2022-02-22 19-48-09](https://user-images.githubusercontent.com/493276/155117264-8ef809b8-4dc5-49bc-8ed0-204c8c17d7f3.png)




Closes #118