### PR TITLE
add missing test_depends

### DIFF
--- a/rwt_app_chooser/package.xml
+++ b/rwt_app_chooser/package.xml
@@ -19,5 +19,6 @@
   <test_depend>phantomjs</test_depend>
   <test_depend>python-selenium-pip</test_depend>
   <test_depend>rostest</test_depend>
+  <test_depend>roslaunch</test_depend>
 
 </package>

--- a/rwt_image_view/package.xml
+++ b/rwt_image_view/package.xml
@@ -29,6 +29,7 @@
   <run_depend>message_runtime</run_depend>
 
   <test_depend>rostest</test_depend>
+  <test_depend>roslaunch</test_depend>
   <test_depend>image_publisher</test_depend>
   <test_depend>rviz</test_depend>
 

--- a/rwt_nav/package.xml
+++ b/rwt_nav/package.xml
@@ -32,6 +32,7 @@
   <run_depend>tf</run_depend>
 
   <test_depend>rostest</test_depend>
+  <test_depend>roslaunch</test_depend>
   <test_depend>image_publisher</test_depend>
   <test_depend>rviz</test_depend>
   <test_depend>map_server</test_depend>

--- a/rwt_plot/package.xml
+++ b/rwt_plot/package.xml
@@ -27,6 +27,7 @@
   <run_depend>roswww</run_depend>
 
   <test_depend>rostest</test_depend>
+  <test_depend>roslaunch</test_depend>
 
   <export></export>
 </package>

--- a/rwt_robot_monitor/package.xml
+++ b/rwt_robot_monitor/package.xml
@@ -26,6 +26,7 @@
   <run_depend>roswww</run_depend>
 
   <test_depend>rostest</test_depend>
+  <test_depend>roslaunch</test_depend>
   <test_depend>diagnostic_aggregator</test_depend>
 
   <export>

--- a/rwt_steer/package.xml
+++ b/rwt_steer/package.xml
@@ -22,6 +22,7 @@
 
   <test_depend>image_publisher</test_depend>
   <test_depend>rviz</test_depend>
+  <test_depend>roslaunch</test_depend>
   <test_depend>rostest</test_depend>
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
fixes https://build.ros.org/job/Nbin_uF64__rwt_app_chooser__ubuntu_focal_amd64__binary/1/console

```
13:43:55 -- Using Python nosetests: /usr/bin/nosetests3
13:43:55 -- catkin 0.8.10
13:43:55 -- BUILD_SHARED_LIBS is on
13:43:55 -- Could NOT find roslaunch (missing: roslaunch_DIR)
13:43:55 -- Could not find the required component 'roslaunch'. The following CMake error indicates that you either need to install the package with the same name or change your environment so that it can be found.
13:43:55 CMake Error at /opt/ros/noetic/share/catkin/cmake/catkinConfig.cmake:83 (find_package):
13:43:55   Could not find a package configuration file provided by "roslaunch" with
13:43:55   any of the following names:
13:43:55
13:43:55     roslaunchConfig.cmake
13:43:55     roslaunch-config.cmake
13:43:55
13:43:55   Add the installation prefix of "roslaunch" to CMAKE_PREFIX_PATH or set
13:43:55   "roslaunch_DIR" to a directory containing one of the above files.  If
13:43:55   "roslaunch" provides a separate development package or SDK, be sure it has
13:43:55   been installed.
13:43:55 Call Stack (most recent call first):
13:43:55   CMakeLists.txt:13 (find_package)
13:43:55
13:43:55
13:43:55 -- Configuring incomplete, errors occurred!
13:43:55 See also "/tmp/binarydeb/ros-noetic-rwt-app-chooser-0.1
```